### PR TITLE
Update cuda-core to 0.6.0

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ stages:
   jobs:
     - job: Skip
       pool:
-        vmImage: 'ubuntu-22.04'
+        vmImage: 'ubuntu-latest'
       variables:
         DECODE_PERCENTS: 'false'
         RET: 'true'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "cuda-core" %}
-{% set version = "0.5.1" %}
-{% set number = 1 %}
+{% set version = "0.6.0" %}
+{% set number = 0 %}
 {% set is_freethreading = environ.get("is_freethreading", False) %}
 
 {% set target_name = "x86_64-linux" %}  # [linux64]
@@ -16,7 +16,7 @@ package:
 
 source:
   url: https://github.com/NVIDIA/cuda-python/releases/download/{{ name }}-v{{ version }}/cuda-python-{{ name }}-v{{ version }}.tar.gz
-  sha256: 00d315553f5f1f491f52e73021ac558b93263d6b1b4f7677cdfa47ae89bc128d
+  sha256: 9618b4afde01671dc3f644431f67f660db52c68b3814ce758eb26fadceaa4bbd
 
 build:
   number: {{ number }}
@@ -26,6 +26,7 @@ build:
     - CUDA_PATH={{ PREFIX ~ subdir }}
   ignore_run_exports_from:
     - cuda-cudart-dev
+    - cuda-nvrtc-dev
 
 requirements:
   build:
@@ -40,7 +41,9 @@ requirements:
     - pip
     - python
     - setuptools
+    - setuptools-scm >=8
     - cuda-cudart-dev
+    - cuda-nvrtc-dev
     - cuda-profiler-api
     - cuda-bindings {{ cuda_major_version }}.*
     - cuda-version {{ cuda_major_version }}.*
@@ -52,14 +55,14 @@ requirements:
 
 test:
   commands:
-    - python -c "from cuda.core.experimental import Device, Buffer, utils; print('ok')"
+    - python -c "from cuda.core import Device, Buffer, utils; print('ok')"
 
 about:
   home: https://nvidia.github.io/cuda-python/cuda-core
   license: Apache-2.0
   license_file: cuda_core/LICENSE
   license_url: https://github.com/NVIDIA/cuda-python/blob/main/cuda_core/LICENSE
-  summary: "cuda.core: (experimental) pythonic CUDA module"
+  summary: "cuda.core: pythonic CUDA module"
   description: |
     cuda.core bridges Python's productivity with CUDA's performance through intuitive and pythonic APIs.
     The mission is to provide users full access to all of the core CUDA features in Python, such as


### PR DESCRIPTION
Update cuda-core to version 0.6.0. Changes: version bump, sha256 update, drop 'experimental' from imports and summary.